### PR TITLE
adding total price to CreateOrderResponse

### DIFF
--- a/.github/workflows/docker-quick-release.yml
+++ b/.github/workflows/docker-quick-release.yml
@@ -3,7 +3,7 @@ name: Build and Push Dev Docker Images to GHCR
 on:
   push:
     branches:
-      - development
+      - release
 
 env:
   REGISTRY: ghcr.io

--- a/OrderService/src/main/java/com/gostavdev/commercify/orderservice/dto/OrderDetails.java
+++ b/OrderService/src/main/java/com/gostavdev/commercify/orderservice/dto/OrderDetails.java
@@ -3,5 +3,6 @@ package com.gostavdev.commercify.orderservice.dto;
 import java.util.List;
 
 public record OrderDetails(OrderDTO order,
+                           Double totalPrice,
                            List<OrderLineDTO> orderLines) {
 }

--- a/OrderService/src/main/java/com/gostavdev/commercify/orderservice/services/OrderService.java
+++ b/OrderService/src/main/java/com/gostavdev/commercify/orderservice/services/OrderService.java
@@ -145,8 +145,9 @@ public class OrderService {
                 .orElseThrow(() -> new IllegalArgumentException("Order not found"));
 
         List<OrderLineDTO> orderLines = getOrderLinesByOrderId(order);
+        double totalPrice = calculateOrderTotal(order.getOrderLines());
 
-        return new OrderDetails(mapper.apply(order), orderLines);
+        return new OrderDetails(mapper.apply(order), totalPrice, orderLines);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
This pull request includes updates to the Docker workflow configuration and enhancements to the order service in the project. The most important changes involve modifying the branches for Docker image builds, adding a new field to the `OrderDetails` record, and updating the order service to calculate and include the total price of an order.

### Docker Workflow Configuration:
* [`.github/workflows/docker-quick-release.yml`](diffhunk://#diff-9e4261cb877deda4bd9fdb1cf0ece4b67a3531926e5e566a8a393ca0a2e35840L6-R6): Changed the branch from `development` to `release` for triggering the Docker image build and push process.

### Order Service Enhancements:
* [`OrderService/src/main/java/com/gostavdev/commercify/orderservice/dto/OrderDetails.java`](diffhunk://#diff-9f048eeeda9a44df5291387433cecec28fdc80cacc4fbbdd0d15173d02b7af07R6): Added a new field `totalPrice` to the `OrderDetails` record.
* [`OrderService/src/main/java/com/gostavdev/commercify/orderservice/services/OrderService.java`](diffhunk://#diff-b2045ba773c7397c6da1720f128ea8af5f391b04b68e53f9503878d68e2f1ad0R148-R150): Updated the `getOrderById` method to calculate the total price of an order and include it in the `OrderDetails` response.renames development branch to release