### PR TITLE
fixes error on product creation

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/service/stripe/StripeProductService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/stripe/StripeProductService.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @Slf4j
 public class StripeProductService {
     public String createStripeProduct(ProductEntity product) {
-        if (Stripe.apiKey == null || product.getStripeId() == null || Stripe.apiKey.isBlank())
+        if (Stripe.apiKey == null || Stripe.apiKey.isBlank())
             throw new RuntimeException("Can't CREATE product in stripe without stripe key");
 
         try {
@@ -34,7 +34,7 @@ public class StripeProductService {
     }
 
     public void updateStripeProduct(String stripeId, ProductEntity product) {
-        if (Stripe.apiKey == null || product.getStripeId() == null || Stripe.apiKey.isBlank())
+        if (Stripe.apiKey == null || Stripe.apiKey.isBlank())
             throw new RuntimeException("Can't UPDATE product in stripe without stripe key");
 
         try {


### PR DESCRIPTION
This pull request includes changes to the `StripeProductService` class to improve the validation logic for Stripe API key checks.

Validation logic improvements:

* [`src/main/java/com/zenfulcode/commercify/commercify/service/stripe/StripeProductService.java`](diffhunk://#diff-e4a95713d32885a47cd15a2bd07599f13176475c4a2aadcb3fd15c7f47484aa2L21-R21): Removed the check for `product.getStripeId()` being null in both the `createStripeProduct` and `updateStripeProduct` methods, simplifying the validation to only check if `Stripe.apiKey` is null or blank. [[1]](diffhunk://#diff-e4a95713d32885a47cd15a2bd07599f13176475c4a2aadcb3fd15c7f47484aa2L21-R21) [[2]](diffhunk://#diff-e4a95713d32885a47cd15a2bd07599f13176475c4a2aadcb3fd15c7f47484aa2L37-R37)