### PR TITLE
fixes error with database when using docker profile

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -5,15 +5,9 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}?createDatabaseIfNotExist=true
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.hibernate.ddl-auto=none
 # Migrations
-spring.flyway.enabled=true
-spring.flyway.locations=classpath:db/migration
-spring.flyway.baseline-on-migrate=true
-spring.flyway.validate-on-migrate=true
-spring.flyway.baseline-version=1
-spring.flyway.baseline-description="initial version"
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 # Other configurations
 security.jwt.expiration-time=3600000
 security.jwt.secret-key=${JWT_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,6 @@ spring.datasource.username=${DATABASE_USER:root}
 spring.datasource.password=${DATABASE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=none
-#spring.jpa.properties.hibernate.format_sql=true
 # Migrations
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 #The secret key must be an HMAC hash string of 256 bits;


### PR DESCRIPTION
This pull request focuses on updating the database configuration in the application properties files. The changes mainly involve switching from Flyway to Liquibase for database migrations and adjusting related settings.

Database migration tool change:

* [`src/main/resources/application-docker.properties`](diffhunk://#diff-d5f595c9b038bef76ae6808b54fcbe110f6a497b1c28ef51dfe68ee78a57b7e3L8-R10): Replaced Flyway configuration with Liquibase configuration by adding `spring.liquibase.change-log` and removing Flyway-related properties.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L9): Updated to use Liquibase for database migrations by adding `spring.liquibase.change-log` and commenting out the Flyway configuration.

Other configuration adjustments:

* [`src/main/resources/application-docker.properties`](diffhunk://#diff-d5f595c9b038bef76ae6808b54fcbe110f6a497b1c28ef51dfe68ee78a57b7e3L8-R10): Changed `spring.jpa.hibernate.ddl-auto` from `validate` to `none`.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L9): Ensured `spring.jpa.hibernate.ddl-auto` is set to `none`.