### PR TITLE
Release addresses not fully populated

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/dto/AddressDTO.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/dto/AddressDTO.java
@@ -16,6 +16,6 @@ public class AddressDTO {
     private String state;
     private String zipCode;
     private String country;
-    private boolean isBillingAddress;
-    private boolean isShippingAddress;
+    private Boolean isBilling;
+    private Boolean isShipping;
 }

--- a/src/main/java/com/zenfulcode/commercify/commercify/dto/mapper/AddressMapper.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/dto/mapper/AddressMapper.java
@@ -10,6 +10,9 @@ import java.util.function.Function;
 public class AddressMapper implements Function<AddressEntity, AddressDTO> {
     @Override
     public AddressDTO apply(AddressEntity address) {
+        System.out.println("billing address: " + address.getIsBillingAddress());
+        System.out.println("shipping address: " + address.getIsShippingAddress());
+
         return AddressDTO.builder()
                 .id(address.getId())
                 .street(address.getStreet())
@@ -17,8 +20,8 @@ public class AddressMapper implements Function<AddressEntity, AddressDTO> {
                 .state(address.getState())
                 .zipCode(address.getZipCode())
                 .country(address.getCountry())
-                .isBillingAddress(address.isBillingAddress())
-                .isShippingAddress(address.isShippingAddress())
+                .isBilling(address.getIsBillingAddress())
+                .isShipping(address.getIsShippingAddress())
                 .build();
     }
 }

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/AddressEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/AddressEntity.java
@@ -35,10 +35,10 @@ public class AddressEntity {
     private String country;
 
     @Column(name = "is_billing_address", nullable = false)
-    private boolean isBillingAddress;
+    private Boolean isBillingAddress;
 
     @Column(name = "is_shipping_address", nullable = false)
-    private boolean isShippingAddress;
+    private Boolean isShippingAddress;
 
     @Column(name = "created_at", nullable = false)
     @CreationTimestamp

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
@@ -55,14 +55,14 @@ public class UserEntity implements UserDetails {
 
     public AddressEntity getBillingAddress() {
         return addresses.stream()
-                .filter(AddressEntity::isBillingAddress)
+                .filter(AddressEntity::getIsBillingAddress)
                 .findFirst()
                 .orElse(null);
     }
 
     public AddressEntity getShippingAddress() {
         return addresses.stream()
-                .filter(AddressEntity::isShippingAddress)
+                .filter(AddressEntity::getIsShippingAddress)
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/com/zenfulcode/commercify/commercify/repository/AddressRepository.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.zenfulcode.commercify.commercify.repository;
+
+import com.zenfulcode.commercify.commercify.entity.AddressEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<AddressEntity, Long> {
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/AuthenticationService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/AuthenticationService.java
@@ -7,6 +7,7 @@ import com.zenfulcode.commercify.commercify.dto.UserDTO;
 import com.zenfulcode.commercify.commercify.dto.mapper.UserMapper;
 import com.zenfulcode.commercify.commercify.entity.AddressEntity;
 import com.zenfulcode.commercify.commercify.entity.UserEntity;
+import com.zenfulcode.commercify.commercify.repository.AddressRepository;
 import com.zenfulcode.commercify.commercify.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @Slf4j
 public class AuthenticationService {
+    private final AddressRepository addressRepository;
     private final UserRepository userRepository;
     private final AuthenticationManager authenticationManager;
     private final UserMapper mapper;
@@ -48,8 +50,8 @@ public class AuthenticationService {
                         .state(addressDTO.getState())
                         .zipCode(addressDTO.getZipCode())
                         .country(addressDTO.getCountry())
-                        .isBillingAddress(addressDTO.isBillingAddress())
-                        .isShippingAddress(addressDTO.isShippingAddress())
+                        .isBillingAddress(addressDTO.getIsBilling())
+                        .isShippingAddress(addressDTO.getIsShipping())
                         .build())
                 .collect(Collectors.toSet());
 
@@ -63,6 +65,10 @@ public class AuthenticationService {
                 .build();
 
         addresses.forEach(address -> address.setUser(user));
+
+        addressRepository.saveAll(addresses);
+
+        log.info("addresse: {}", addresses);
 
         UserEntity savedUser = userRepository.save(user);
         return mapper.apply(savedUser);

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/UserManagementService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/UserManagementService.java
@@ -65,8 +65,8 @@ public class UserManagementService {
                 .state(addressDTO.getState())
                 .zipCode(addressDTO.getZipCode())
                 .country(addressDTO.getCountry())
-                .isBillingAddress(addressDTO.isBillingAddress())
-                .isShippingAddress(addressDTO.isShippingAddress())
+                .isBillingAddress(addressDTO.getIsBilling())
+                .isShippingAddress(addressDTO.getIsShipping())
                 .user(user)
                 .build();
 
@@ -90,8 +90,8 @@ public class UserManagementService {
         address.setState(addressDTO.getState());
         address.setZipCode(addressDTO.getZipCode());
         address.setCountry(addressDTO.getCountry());
-        address.setBillingAddress(addressDTO.isBillingAddress());
-        address.setShippingAddress(addressDTO.isShippingAddress());
+        address.setIsBillingAddress(addressDTO.getIsBilling());
+        address.setIsShippingAddress(addressDTO.getIsShipping());
 
         UserEntity updatedUser = userRepository.save(user);
         return mapper.apply(updatedUser);

--- a/src/test/java/com/zenfulcode/commercify/commercify/entity/UserEntityTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/entity/UserEntityTest.java
@@ -87,7 +87,7 @@ class UserEntityTest {
         void testGetBillingAddress() {
             AddressEntity billingAddress = user.getBillingAddress();
             assertNotNull(billingAddress);
-            assertTrue(billingAddress.isBillingAddress());
+            assertTrue(billingAddress.getIsBillingAddress());
             assertEquals("123 Test St", billingAddress.getStreet());
         }
 
@@ -109,7 +109,7 @@ class UserEntityTest {
 
             AddressEntity retrievedAddress = user.getShippingAddress();
             assertNotNull(retrievedAddress);
-            assertTrue(retrievedAddress.isShippingAddress());
+            assertTrue(retrievedAddress.getIsShippingAddress());
             assertEquals("456 Ship St", retrievedAddress.getStreet());
         }
 

--- a/src/test/java/com/zenfulcode/commercify/commercify/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/service/AuthenticationServiceTest.java
@@ -7,6 +7,7 @@ import com.zenfulcode.commercify.commercify.dto.AddressDTO;
 import com.zenfulcode.commercify.commercify.dto.UserDTO;
 import com.zenfulcode.commercify.commercify.dto.mapper.UserMapper;
 import com.zenfulcode.commercify.commercify.entity.UserEntity;
+import com.zenfulcode.commercify.commercify.repository.AddressRepository;
 import com.zenfulcode.commercify.commercify.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,8 @@ class AuthenticationServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private AddressRepository addressRepository;
     @Mock
     private AuthenticationManager authenticationManager;
 

--- a/src/test/java/com/zenfulcode/commercify/commercify/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/service/AuthenticationServiceTest.java
@@ -61,8 +61,8 @@ class AuthenticationServiceTest {
                 .state("Test State")
                 .zipCode("12345")
                 .country("Test Country")
-                .isBillingAddress(true)
-                .isShippingAddress(false)
+                .isBilling(true)
+                .isShipping(false)
                 .build();
 
         registerRequest = new RegisterUserRequest(


### PR DESCRIPTION
This pull request makes several important changes to the `AddressEntity` and related classes, primarily focusing on modifying the data types of certain fields and adding a new repository. These changes also include updates to methods, constructors, and tests to accommodate the new data types.

### Data Type Changes:
* Changed `isBillingAddress` and `isShippingAddress` from `boolean` to `Boolean` in `AddressDTO`, `AddressEntity`, and related methods. [[1]](diffhunk://#diff-a22c94a968792652007015d8765d469d5964e293bf683565747c01c83487279bL19-R20) [[2]](diffhunk://#diff-18f204ab25dd4a4ce01c140049ced2335bf5aa8eeb96961b79185dc780de5f1bL38-R41) [[3]](diffhunk://#diff-519f5ff602207c50a3d79f94f183c4e91ed3132215273cbd29ef2f80a48fef7fL51-R54) [[4]](diffhunk://#diff-9e6a22d243d7b713993920a153d4f32ff07a9a2835614adef36a97529a176d55L68-R69) [[5]](diffhunk://#diff-9e6a22d243d7b713993920a153d4f32ff07a9a2835614adef36a97529a176d55L93-R94)

### Repository Addition:
* Added `AddressRepository` interface extending `JpaRepository` for `AddressEntity`.

### Service Layer Updates:
* Injected `AddressRepository` into `AuthenticationService` and updated the `registerUser` method to save addresses using `addressRepository`. [[1]](diffhunk://#diff-519f5ff602207c50a3d79f94f183c4e91ed3132215273cbd29ef2f80a48fef7fR10) [[2]](diffhunk://#diff-519f5ff602207c50a3d79f94f183c4e91ed3132215273cbd29ef2f80a48fef7fR29) [[3]](diffhunk://#diff-519f5ff602207c50a3d79f94f183c4e91ed3132215273cbd29ef2f80a48fef7fR69-R72)

### Logging and Debugging:
* Added logging statements in `AddressMapper` to print billing and shipping address information.

### Test Updates:
* Updated tests to reflect changes in data types for `isBillingAddress` and `isShippingAddress`. [[1]](diffhunk://#diff-113f0a095f8882dad0f3b1e21736243b20afcd1292be26c7ea6f27de97985f38L90-R90) [[2]](diffhunk://#diff-113f0a095f8882dad0f3b1e21736243b20afcd1292be26c7ea6f27de97985f38L112-R112) [[3]](diffhunk://#diff-585b7aaf96c1a38736b38188f4a537c370afaa0468d69b4f59fbbd7079862825R10) [[4]](diffhunk://#diff-585b7aaf96c1a38736b38188f4a537c370afaa0468d69b4f59fbbd7079862825R37-R38) [[5]](diffhunk://#diff-585b7aaf96c1a38736b38188f4a537c370afaa0468d69b4f59fbbd7079862825L64-R68)