### PR TITLE
Jwt error handling and making productsById accessable

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/api/responses/products/JwtErrorResponse.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/api/responses/products/JwtErrorResponse.java
@@ -1,0 +1,22 @@
+package com.zenfulcode.commercify.commercify.api.responses.products;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class JwtErrorResponse {
+    private int status;
+    private String message;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+    private String error;
+
+    public JwtErrorResponse(String message, String error) {
+        this.status = 401;
+        this.message = message;
+        this.error = error;
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java
@@ -30,7 +30,10 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> req
-                        .requestMatchers("/api/v1/auth/**", "/api/v1/products/active").permitAll()
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/api/v1/products/active",
+                                "/api/v1/products/{id}").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
This pull request introduces several changes to enhance JWT error handling and update security configurations in the `commercify` project. The main updates include the creation of a new `JwtErrorResponse` class, integration of this class into the `JwtAuthenticationFilter`, and updates to the security configuration to permit additional endpoints.

Enhancements to JWT error handling:

* [`src/main/java/com/zenfulcode/commercify/commercify/api/responses/products/JwtErrorResponse.java`](diffhunk://#diff-8bf49f3abd4e8c5de17c84d56a42787f57eba74eae55ee77b0f11644e3e0ec38R1-R22): Added a new `JwtErrorResponse` class to standardize JWT error responses.
* [`src/main/java/com/zenfulcode/commercify/commercify/config/JwtAuthenticationFilter.java`](diffhunk://#diff-49be7d69c89022b4e73d583e7ddfe509e6a02b85ea2dab2e3cd8e8a9bd94d170R4-R14): Integrated the `JwtErrorResponse` class into `JwtAuthenticationFilter` to handle expired and generic JWT exceptions, and added necessary imports and object mapper initialization. [[1]](diffhunk://#diff-49be7d69c89022b4e73d583e7ddfe509e6a02b85ea2dab2e3cd8e8a9bd94d170R4-R14) [[2]](diffhunk://#diff-49be7d69c89022b4e73d583e7ddfe509e6a02b85ea2dab2e3cd8e8a9bd94d170R31) [[3]](diffhunk://#diff-49be7d69c89022b4e73d583e7ddfe509e6a02b85ea2dab2e3cd8e8a9bd94d170R41-R42) [[4]](diffhunk://#diff-49be7d69c89022b4e73d583e7ddfe509e6a02b85ea2dab2e3cd8e8a9bd94d170R69-R97)

Updates to security configurations:

* [`src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java`](diffhunk://#diff-ed746dca5b083facdaee9e0f7590c73742e2f6bafa0d27f9639ae4edd8ed2e17L33-R36): Updated security configuration to permit access to the `/api/v1/products/{id}` endpoint.