### PR TITLE
updates service tests for orders and products

### DIFF
--- a/src/test/java/com/zenfulcode/commercify/commercify/service/order/OrderServiceTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/service/order/OrderServiceTest.java
@@ -1,0 +1,243 @@
+package com.zenfulcode.commercify.commercify.service.order;
+
+import com.zenfulcode.commercify.commercify.OrderStatus;
+import com.zenfulcode.commercify.commercify.api.requests.orders.CreateOrderLineRequest;
+import com.zenfulcode.commercify.commercify.api.requests.orders.CreateOrderRequest;
+import com.zenfulcode.commercify.commercify.dto.OrderDTO;
+import com.zenfulcode.commercify.commercify.dto.ProductDTO;
+import com.zenfulcode.commercify.commercify.dto.mapper.OrderMapper;
+import com.zenfulcode.commercify.commercify.entity.OrderEntity;
+import com.zenfulcode.commercify.commercify.entity.OrderLineEntity;
+import com.zenfulcode.commercify.commercify.entity.ProductEntity;
+import com.zenfulcode.commercify.commercify.exception.OrderNotFoundException;
+import com.zenfulcode.commercify.commercify.exception.ProductNotFoundException;
+import com.zenfulcode.commercify.commercify.repository.OrderRepository;
+import com.zenfulcode.commercify.commercify.repository.ProductRepository;
+import com.zenfulcode.commercify.commercify.service.StockManagementService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private OrderMapper orderMapper;
+    @Mock
+    private OrderValidationService validationService;
+    @Mock
+    private OrderCalculationService calculationService;
+    @Mock
+    private StockManagementService stockService;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    private OrderEntity orderEntity;
+    private OrderDTO orderDTO;
+    private CreateOrderRequest createOrderRequest;
+    private ProductEntity productEntity;
+    private ProductDTO productDTO;
+
+    @BeforeEach
+    void setUp() {
+        productEntity = ProductEntity.builder()
+                .id(1L)
+                .name("Test Product")
+                .active(true)
+                .stock(10)
+                .unitPrice(99.99)
+                .currency("USD")
+                .build();
+
+        OrderLineEntity orderLine = OrderLineEntity.builder()
+                .id(1L)
+                .productId(1L)
+                .quantity(2)
+                .unitPrice(99.99)
+                .currency("USD")
+                .build();
+
+        orderEntity = OrderEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .currency("USD")
+                .totalAmount(199.98)
+                .orderLines(Set.of(orderLine))
+                .createdAt(Instant.now())
+                .build();
+
+        orderDTO = OrderDTO.builder()
+                .id(1L)
+                .userId(1L)
+                .orderStatus(OrderStatus.PENDING)
+                .currency("USD")
+                .totalAmount(199.98)
+                .build();
+
+        CreateOrderLineRequest orderLineRequest = new CreateOrderLineRequest(1L, null, 2);
+        createOrderRequest = new CreateOrderRequest("USD", List.of(orderLineRequest));
+    }
+
+    @Nested
+    @DisplayName("Create Order Tests")
+    class CreateOrderTests {
+
+        @Test
+        @DisplayName("Should create order successfully")
+        void createOrder_Success() {
+            when(productRepository.findAllById(any())).thenReturn(List.of(productEntity));
+            when(calculationService.calculateTotalAmount(any())).thenReturn(199.98);
+            when(orderRepository.save(any())).thenReturn(orderEntity);
+            when(orderMapper.apply(any())).thenReturn(orderDTO);
+
+            OrderDTO result = orderService.createOrder(1L, createOrderRequest);
+
+            assertNotNull(result);
+            assertEquals(orderDTO.getId(), result.getId());
+            assertEquals(orderDTO.getTotalAmount(), result.getTotalAmount());
+            verify(validationService).validateCreateOrderRequest(createOrderRequest);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when product not found")
+        void createOrder_ProductNotFound() {
+            when(productRepository.findAllById(any())).thenReturn(Collections.emptyList());
+
+            assertThrows(ProductNotFoundException.class,
+                    () -> orderService.createOrder(1L, createOrderRequest));
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Order Status Tests")
+    class UpdateOrderStatusTests {
+
+        @Test
+        @DisplayName("Should update order status successfully")
+        void updateOrderStatus_Success() {
+            when(orderRepository.findById(1L)).thenReturn(Optional.of(orderEntity));
+            when(orderRepository.save(any())).thenReturn(orderEntity);
+
+            assertDoesNotThrow(() ->
+                    orderService.updateOrderStatus(1L, OrderStatus.CONFIRMED));
+            assertEquals(OrderStatus.CONFIRMED, orderEntity.getStatus());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when order not found")
+        void updateOrderStatus_OrderNotFound() {
+            when(orderRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(OrderNotFoundException.class,
+                    () -> orderService.updateOrderStatus(1L, OrderStatus.CONFIRMED));
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Orders Tests")
+    class GetOrdersTests {
+
+        @Test
+        @DisplayName("Should get orders by user ID")
+        void getOrdersByUserId_Success() {
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Page<OrderEntity> orderPage = new PageImpl<>(List.of(orderEntity));
+
+            when(orderRepository.findByUserId(1L, pageRequest)).thenReturn(orderPage);
+            when(orderMapper.apply(any())).thenReturn(orderDTO);
+
+            Page<OrderDTO> result = orderService.getOrdersByUserId(1L, pageRequest);
+
+            assertNotNull(result);
+            assertEquals(1, result.getContent().size());
+            verify(orderRepository).findByUserId(1L, pageRequest);
+        }
+
+        @Test
+        @DisplayName("Should get all orders")
+        void getAllOrders_Success() {
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            Page<OrderEntity> orderPage = new PageImpl<>(List.of(orderEntity));
+
+            when(orderRepository.findAll(pageRequest)).thenReturn(orderPage);
+            when(orderMapper.apply(any())).thenReturn(orderDTO);
+
+            Page<OrderDTO> result = orderService.getAllOrders(pageRequest);
+
+            assertNotNull(result);
+            assertEquals(1, result.getContent().size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cancel Order Tests")
+    class CancelOrderTests {
+
+        @Test
+        @DisplayName("Should cancel order successfully")
+        void cancelOrder_Success() {
+            when(orderRepository.findById(1L)).thenReturn(Optional.of(orderEntity));
+            doNothing().when(validationService).validateOrderCancellation(orderEntity);
+            when(orderRepository.save(any())).thenReturn(orderEntity);
+
+            assertDoesNotThrow(() -> orderService.cancelOrder(1L));
+            assertEquals(OrderStatus.CANCELLED, orderEntity.getStatus());
+            verify(stockService).restoreStockLevels(orderEntity.getOrderLines());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when cancelling non-existent order")
+        void cancelOrder_OrderNotFound() {
+            when(orderRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(OrderNotFoundException.class,
+                    () -> orderService.cancelOrder(1L));
+            verify(stockService, never()).restoreStockLevels(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Order Ownership Tests")
+    class OrderOwnershipTests {
+
+        @Test
+        @DisplayName("Should verify order ownership")
+        void isOrderOwnedByUser_Success() {
+            when(orderRepository.existsByIdAndUserId(1L, 1L)).thenReturn(true);
+
+            assertTrue(orderService.isOrderOwnedByUser(1L, 1L));
+        }
+
+        @Test
+        @DisplayName("Should verify order not owned by user")
+        void isOrderOwnedByUser_NotOwned() {
+            when(orderRepository.existsByIdAndUserId(1L, 2L)).thenReturn(false);
+
+            assertFalse(orderService.isOrderOwnedByUser(1L, 2L));
+        }
+    }
+}

--- a/src/test/java/com/zenfulcode/commercify/commercify/service/product/ProductServiceTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/service/product/ProductServiceTest.java
@@ -1,0 +1,241 @@
+package com.zenfulcode.commercify.commercify.service.product;
+
+import com.zenfulcode.commercify.commercify.api.requests.products.PriceRequest;
+import com.zenfulcode.commercify.commercify.api.requests.products.ProductRequest;
+import com.zenfulcode.commercify.commercify.dto.ProductDTO;
+import com.zenfulcode.commercify.commercify.dto.mapper.ProductMapper;
+import com.zenfulcode.commercify.commercify.entity.ProductEntity;
+import com.zenfulcode.commercify.commercify.exception.ProductNotFoundException;
+import com.zenfulcode.commercify.commercify.factory.ProductFactory;
+import com.zenfulcode.commercify.commercify.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private ProductMapper productMapper;
+    @Mock
+    private ProductFactory productFactory;
+    @Mock
+    private ProductValidationService validationService;
+    @Mock
+    private ProductVariantService variantService;
+    
+    @InjectMocks
+    private ProductService productService;
+
+    private ProductEntity productEntity;
+    private ProductDTO productDTO;
+    private ProductRequest productRequest;
+
+    @BeforeEach
+    void setUp() {
+        productEntity = ProductEntity.builder()
+                .id(1L)
+                .name("Test Product")
+                .description("Test Description")
+                .stock(10)
+                .active(true)
+                .imageUrl("test-image.jpg")
+                .currency("USD")
+                .unitPrice(99.99)
+                .build();
+
+        productDTO = ProductDTO.builder()
+                .id(1L)
+                .name("Test Product")
+                .description("Test Description")
+                .stock(10)
+                .active(true)
+                .imageUrl("test-image.jpg")
+                .currency("USD")
+                .unitPrice(99.99)
+                .variants(new ArrayList<>())
+                .build();
+
+        productRequest = new ProductRequest(
+                "Test Product",
+                "Test Description",
+                10,
+                "test-image.jpg",
+                true,
+                new PriceRequest("USD", 99.99),
+                new ArrayList<>()
+        );
+    }
+
+    @Nested
+    @DisplayName("Create Product Tests")
+    class CreateProductTests {
+
+        @Test
+        @DisplayName("Should create product successfully")
+        void createProduct_Success() {
+            when(productFactory.createFromRequest(any())).thenReturn(productEntity);
+            when(productRepository.save(any())).thenReturn(productEntity);
+            when(productMapper.apply(any())).thenReturn(productDTO);
+
+            ProductDTO result = productService.saveProduct(productRequest);
+
+            assertNotNull(result);
+            assertEquals(productDTO.getName(), result.getName());
+            assertEquals(productDTO.getUnitPrice(), result.getUnitPrice());
+            verify(validationService).validateProductRequest(productRequest);
+        }
+    }
+
+    @Nested
+    @DisplayName("Retrieve Product Tests")
+    class RetrieveProductTests {
+
+        @Test
+        @DisplayName("Should get product by ID")
+        void getProductById_Success() {
+            when(productRepository.findById(1L)).thenReturn(Optional.of(productEntity));
+            when(productMapper.apply(productEntity)).thenReturn(productDTO);
+
+            ProductDTO result = productService.getProductById(1L);
+
+            assertNotNull(result);
+            assertEquals(1L, result.getId());
+            assertEquals("Test Product", result.getName());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when product not found")
+        void getProductById_NotFound() {
+            when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ProductNotFoundException.class, () -> productService.getProductById(1L));
+        }
+
+        @Test
+        @DisplayName("Should get all active products")
+        void getActiveProducts_Success() {
+            PageRequest pageRequest = PageRequest.of(0, 10);
+            List<ProductEntity> products = List.of(productEntity);
+            Page<ProductEntity> productPage = new PageImpl<>(products);
+
+            when(productRepository.queryAllByActiveTrue(pageRequest)).thenReturn(productPage);
+            when(productMapper.apply(any())).thenReturn(productDTO);
+
+            Page<ProductDTO> result = productService.getActiveProducts(pageRequest);
+
+            assertNotNull(result);
+            assertEquals(1, result.getContent().size());
+            verify(productRepository).queryAllByActiveTrue(pageRequest);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Product Tests")
+    class UpdateProductTests {
+
+        @Test
+        @DisplayName("Should update product successfully")
+        void updateProduct_Success() {
+            when(productRepository.findById(1L)).thenReturn(Optional.of(productEntity));
+            when(productRepository.save(any())).thenReturn(productEntity);
+            when(productMapper.apply(any())).thenReturn(productDTO);
+
+            var result = productService.updateProduct(1L, productRequest);
+
+            assertNotNull(result);
+            assertEquals(productDTO, result.getProduct());
+            assertTrue(result.getWarnings().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when updating non-existent product")
+        void updateProduct_NotFound() {
+            when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ProductNotFoundException.class,
+                    () -> productService.updateProduct(1L, productRequest));
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Product Tests")
+    class DeleteProductTests {
+        @Mock
+        private ProductDeletionService productDeletionService;
+
+        @BeforeEach
+        void setUp() {
+            productService = new ProductService(
+                    productRepository,
+                    productMapper,
+                    productFactory,
+                    validationService,
+                    variantService,
+                    productDeletionService
+            );
+        }
+
+        @Test
+        @DisplayName("Should delete product successfully")
+        void deleteProduct_Success() {
+            when(productRepository.findById(1L)).thenReturn(Optional.of(productEntity));
+            doNothing().when(productDeletionService).validateAndDelete(productEntity);
+
+            assertDoesNotThrow(() -> productService.deleteProduct(1L));
+            verify(productDeletionService).validateAndDelete(productEntity);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when deleting non-existent product")
+        void deleteProduct_NotFound() {
+            when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ProductNotFoundException.class, () -> productService.deleteProduct(1L));
+            verify(productDeletionService, never()).validateAndDelete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Product Status Tests")
+    class ProductStatusTests {
+
+        @Test
+        @DisplayName("Should activate product")
+        void activateProduct_Success() {
+            when(productRepository.findById(1L)).thenReturn(Optional.of(productEntity));
+
+            assertDoesNotThrow(() -> productService.reactivateProduct(1L));
+            assertTrue(productEntity.getActive());
+            verify(productRepository).save(productEntity);
+        }
+
+        @Test
+        @DisplayName("Should deactivate product")
+        void deactivateProduct_Success() {
+            when(productRepository.findById(1L)).thenReturn(Optional.of(productEntity));
+
+            assertDoesNotThrow(() -> productService.deactivateProduct(1L));
+            assertFalse(productEntity.getActive());
+            verify(productRepository).save(productEntity);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the `OrderService` and `ProductService` classes. The new tests cover various functionalities, including creation, retrieval, updating, and deletion of orders and products. The most important changes are summarized below:

### OrderService Tests:
* [`OrderServiceTest.java`](diffhunk://#diff-1cbc26d77f69228c8b8ae428b0006c7cc2f6821b0df6e9a85bf598e04db20765R1-R243): Added tests for creating orders, updating order status, retrieving orders by user ID, and canceling orders.

### ProductService Tests:
* [`ProductServiceTest.java`](diffhunk://#diff-cadbc87212d7635c41dd2b110e4b9689f64977d38d88a70fd3f4cc9d09bc65ccR1-R241): Added tests for creating products, retrieving products by ID, updating products, and deleting products.