### PR TITLE
Release user confirmation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,18 @@
             <artifactId>spring-retry</artifactId>
             <version>2.0.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zenfulcode/commercify/commercify/component/AdminDataLoader.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/component/AdminDataLoader.java
@@ -33,6 +33,9 @@ public class AdminDataLoader {
                         .firstName("Admin")
                         .lastName("User")
                         .roles(List.of("ADMIN", "USER"))
+                        .shippingAddress(null)
+                        .billingAddress(null)
+                        .emailConfirmed(true)
                         .build();
 
                 userRepository.save(adminUser);

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/ConfirmationTokenEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/ConfirmationTokenEntity.java
@@ -22,7 +22,7 @@ public class ConfirmationTokenEntity {
     @Column(nullable = false, unique = true)
     private String token;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "expiry_date")
     private Instant expiryDate;
 
     @Column(nullable = false)
@@ -33,7 +33,7 @@ public class ConfirmationTokenEntity {
     private UserEntity user;
 
     @CreationTimestamp
-    @Column(nullable = false)
+    @Column(nullable = false, name = "created_at")
     private Instant createdAt;
 
     @PrePersist

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/ConfirmationTokenEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/ConfirmationTokenEntity.java
@@ -1,0 +1,48 @@
+package com.zenfulcode.commercify.commercify.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "confirmation_tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConfirmationTokenEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+    @Column(nullable = false)
+    private boolean confirmed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (token == null) {
+            token = UUID.randomUUID().toString();
+        }
+        if (expiryDate == null) {
+            expiryDate = Instant.now().plusSeconds(24 * 60 * 60); // 24 hours
+        }
+    }
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
@@ -54,8 +54,8 @@ public class UserEntity implements UserDetails {
     @Column(name = "role")
     private List<String> roles;
 
-    @Column(nullable = false)
-    private boolean emailConfirmed = false;
+    @Column(nullable = false, name = "email_confirmed")
+    private Boolean emailConfirmed = false;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude

--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
@@ -10,7 +10,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Table(name = "users")
@@ -51,6 +53,13 @@ public class UserEntity implements UserDetails {
     @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "id"))
     @Column(name = "role")
     private List<String> roles;
+
+    @Column(nullable = false)
+    private boolean emailConfirmed = false;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private Set<ConfirmationTokenEntity> confirmationTokens = new HashSet<>();
 
     @Column(name = "created_at", nullable = false)
     @CreationTimestamp
@@ -109,6 +118,6 @@ public class UserEntity implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return emailConfirmed;
     }
 }

--- a/src/main/java/com/zenfulcode/commercify/commercify/repository/ConfirmationTokenRepository.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/repository/ConfirmationTokenRepository.java
@@ -1,0 +1,13 @@
+package com.zenfulcode.commercify.commercify.repository;
+
+import com.zenfulcode.commercify.commercify.entity.ConfirmationTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ConfirmationTokenRepository extends JpaRepository<ConfirmationTokenEntity, Long> {
+    Optional<ConfirmationTokenEntity> findByToken(String token);
+    Optional<ConfirmationTokenEntity> findByUserIdAndConfirmedFalse(Long userId);
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/AuthenticationService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/AuthenticationService.java
@@ -8,6 +8,7 @@ import com.zenfulcode.commercify.commercify.dto.mapper.UserMapper;
 import com.zenfulcode.commercify.commercify.entity.AddressEntity;
 import com.zenfulcode.commercify.commercify.entity.UserEntity;
 import com.zenfulcode.commercify.commercify.repository.UserRepository;
+import com.zenfulcode.commercify.commercify.service.email.EmailConfirmationService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,6 +29,7 @@ public class AuthenticationService {
     private final UserMapper mapper;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
+    private final EmailConfirmationService emailConfirmationService;
 
     @Transactional
     public UserDTO registerUser(RegisterUserRequest registerRequest) {
@@ -70,9 +72,14 @@ public class AuthenticationService {
                 .roles(List.of("USER"))
                 .shippingAddress(shippingAddress)
                 .billingAddress(billingAddress)
+                .emailConfirmed(false)
                 .build();
 
         UserEntity savedUser = userRepository.save(user);
+
+        emailConfirmationService.createConfirmationToken(savedUser);
+
+
         return mapper.apply(savedUser);
     }
 

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/EmailService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/EmailService.java
@@ -1,0 +1,44 @@
+package com.zenfulcode.commercify.commercify.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @Async
+    public void sendConfirmationEmail(String to, String token) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+        Context context = new Context();
+        context.setVariable("confirmationUrl",
+                frontendUrl + "/confirm-email?token=" + token);
+
+        String htmlContent = templateEngine.process("confirmation-email", context);
+
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject("Confirm your email address");
+        helper.setText(htmlContent, true);
+
+        mailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/email/EmailConfirmationService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/email/EmailConfirmationService.java
@@ -1,0 +1,77 @@
+package com.zenfulcode.commercify.commercify.service.email;
+
+import com.zenfulcode.commercify.commercify.entity.ConfirmationTokenEntity;
+import com.zenfulcode.commercify.commercify.entity.UserEntity;
+import com.zenfulcode.commercify.commercify.repository.ConfirmationTokenRepository;
+import com.zenfulcode.commercify.commercify.repository.UserRepository;
+import com.zenfulcode.commercify.commercify.service.EmailService;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class EmailConfirmationService {
+    private final ConfirmationTokenRepository tokenRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Transactional
+    public void createConfirmationToken(UserEntity user) {
+        // Delete any existing unconfirmed tokens
+        tokenRepository.findByUserIdAndConfirmedFalse(user.getId())
+                .ifPresent(tokenRepository::delete);
+
+        // Create new token
+        ConfirmationTokenEntity token = ConfirmationTokenEntity.builder()
+                .user(user)
+                .confirmed(false)
+                .build();
+
+        ConfirmationTokenEntity savedToken = tokenRepository.save(token);
+
+        try {
+            emailService.sendConfirmationEmail(user.getEmail(), savedToken.getToken());
+        } catch (MessagingException e) {
+            throw new RuntimeException("Failed to send confirmation email", e);
+        }
+    }
+
+    @Transactional
+    public boolean confirmEmail(String token) {
+        ConfirmationTokenEntity confirmationToken = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new RuntimeException("Invalid confirmation token"));
+
+        if (confirmationToken.isConfirmed()) {
+            throw new RuntimeException("Email already confirmed");
+        }
+
+        if (Instant.now().isAfter(confirmationToken.getExpiryDate())) {
+            throw new RuntimeException("Confirmation token expired");
+        }
+
+        confirmationToken.setConfirmed(true);
+        UserEntity user = confirmationToken.getUser();
+        user.setEmailConfirmed(true);
+
+        tokenRepository.save(confirmationToken);
+        userRepository.save(user);
+
+        return true;
+    }
+
+    @Transactional
+    public void resendConfirmationEmail(Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        if (user.isEmailConfirmed()) {
+            throw new RuntimeException("Email already confirmed");
+        }
+
+        createConfirmationToken(user);
+    }
+}

--- a/src/main/java/com/zenfulcode/commercify/commercify/service/email/EmailConfirmationService.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/service/email/EmailConfirmationService.java
@@ -68,7 +68,7 @@ public class EmailConfirmationService {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        if (user.isEmailConfirmed()) {
+        if (user.isEnabled()) {
             throw new RuntimeException("Email already confirmed");
         }
 

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -25,3 +25,14 @@ mobilepay.client-secret=${MOBILEPAY_CLIENT_SECRET}
 mobilepay.subscription-key=${MOBILEPAY_SUBSCRIPTION_KEY}
 mobilepay.api-url=${MOBILEPAY_API_URL:https://api.vipps.no}
 mobilepay.system-name=${MOBILEPAY_SYSTEM_NAME:commercify}
+
+# Email Configuration
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Application Configuration
+app.frontend-url=${FRONTEND_URL:http://localhost:3000}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,14 @@ mobilepay.client-secret=${MOBILEPAY_CLIENT_SECRET}
 mobilepay.subscription-key=${MOBILEPAY_SUBSCRIPTION_KEY}
 mobilepay.api-url=${MOBILEPAY_API_URL:https://apitest.vipps.no}
 mobilepay.system-name=${MOBILEPAY_SYSTEM_NAME:commercify}
+
+# Email Configuration
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Application Configuration
+app.frontend-url=${FRONTEND_URL:http://localhost:3000}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,14 +22,12 @@ mobilepay.client-secret=${MOBILEPAY_CLIENT_SECRET}
 mobilepay.subscription-key=${MOBILEPAY_SUBSCRIPTION_KEY}
 mobilepay.api-url=${MOBILEPAY_API_URL:https://apitest.vipps.no}
 mobilepay.system-name=${MOBILEPAY_SYSTEM_NAME:commercify}
-
 # Email Configuration
-spring.mail.host=smtp.gmail.com
+spring.mail.host=smtp.ethereal.email
 spring.mail.port=587
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
-
 # Application Configuration
 app.frontend-url=${FRONTEND_URL:http://localhost:3000}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,4 +9,5 @@
     <include file="db/changelog/migrations/241115135357-changelog.xml"/>
     <include file="db/changelog/migrations/241115144659-changelog.xml"/>
     <include file="db/changelog/migrations/241121174307-changelog.xml"/>
+    <include file="db/changelog/migrations/241127144629-changelog.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/241127144629-changelog.xml
+++ b/src/main/resources/db/changelog/migrations/241127144629-changelog.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1732715189373-1" author="gkhaavik">
+        <createTable tableName="confirmation_tokens">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_confirmation_tokens"/>
+            </column>
+            <column name="token" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expiry_date" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="confirmed" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1732715189373-2" author="gkhaavik">
+        <addColumn tableName="users">
+            <column name="email_confirmed" type="BOOLEAN"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1732715189373-3" author="gkhaavik">
+        <addNotNullConstraint columnDataType="BOOLEAN" columnName="email_confirmed" tableName="users"
+                              defaultNullValue="0"/>
+    </changeSet>
+    <changeSet id="1732715189373-4" author="gkhaavik">
+        <addUniqueConstraint columnNames="token" constraintName="uc_confirmation_tokens_token"
+                             tableName="confirmation_tokens"/>
+    </changeSet>
+    <changeSet id="1732715189373-5" author="gkhaavik">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="confirmation_tokens"
+                                 constraintName="FK_CONFIRMATION_TOKENS_ON_USER" referencedColumnNames="id"
+                                 referencedTableName="users"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/templates/confirmation-email.html
+++ b/src/main/resources/templates/confirmation-email.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title>Confirm your email</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<h1>Welcome to Commercify!</h1>
+<p>Thank you for registering. Please click the link below to confirm your email address:</p>
+<p>
+    <a th:href="${confirmationUrl}" th:text="${confirmationUrl}">Confirmation Link</a>
+</p>
+<p>This link will expire in 24 hours.</p>
+<p>If you did not create an account, please ignore this email.</p>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a comprehensive email confirmation system to the `commercify` project. The changes include adding new dependencies, creating new entities and services for handling email confirmation, and updating existing entities and configurations.

Key changes include:

### Dependencies
* Added `spring-boot-starter-mail`, `spring-boot-starter-thymeleaf`, and `thymeleaf-extras-springsecurity6` dependencies in `pom.xml` to support email functionalities.

### Entities and Repositories
* Created a new entity `ConfirmationTokenEntity` to store email confirmation tokens.
* Updated `UserEntity` to include `emailConfirmed` field and a relationship with `ConfirmationTokenEntity`.
* Created `ConfirmationTokenRepository` for accessing confirmation tokens.

### Services
* Added `EmailService` to handle sending confirmation emails.
* Added `EmailConfirmationService` to create, confirm, and resend confirmation tokens.
* Updated `AuthenticationService` to generate confirmation tokens upon user registration.

### Configuration
* Added email configuration properties in `application-docker.properties` and `application.properties`. [[1]](diffhunk://#diff-d5f595c9b038bef76ae6808b54fcbe110f6a497b1c28ef51dfe68ee78a57b7e3R28-R38) [[2]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R25-R33)
* Added Liquibase changeset to create `confirmation_tokens` table and update `users` table.

These changes collectively enable the email confirmation feature, ensuring that users need to confirm their email addresses before their accounts become fully active.