### PR TITLE
adding a tag parameter to make push command "make push tag=<version>"

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,5 +18,5 @@ build:
 	docker build -t ghcr.io/zenfulcode/commercify:$(tag) .
 
 push:
-	docker build -t ghcr.io/zenfulcode/commercify:dev .
-	docker push ghcr.io/zenfulcode/commercify:dev
+	docker build -t ghcr.io/zenfulcode/commercify:$(tag) .
+	docker push ghcr.io/zenfulcode/commercify:$(tag)


### PR DESCRIPTION
This pull request includes a change to the `makefile` to improve the consistency of the Docker image tagging process.

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L21-R22): Updated the `push` target to use the same tag variable `$(tag)` as the `build` target, ensuring that the Docker image is built and pushed with a consistent tag.