### PR TITLE
fixing unauthenticated users aka guests, could make order requests

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java
@@ -35,7 +35,10 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/**",
                                 "/api/v1/products/active",
-                                "/api/v1/products/{id}").permitAll()
+                                "/api/v1/products/{id}",
+                                "/api/v1/orders",
+                                "/api/v1/payments/mobilepay/create",
+                                "/api/v1/payments/stripe/create").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(smc -> smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/zenfulcode/commercify/commercify/controller/OrderController.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/controller/OrderController.java
@@ -37,6 +37,7 @@ public class OrderController {
             "id", "userId", "status", "currency", "totalAmount", "createdAt", "updatedAt"
     );
 
+    @PreAuthorize("hasRole('USER') and #userId == authentication.principal.id")
     @PostMapping("/{userId}")
     public ResponseEntity<?> createOrder(@PathVariable Long userId, @RequestBody CreateOrderRequest orderRequest) {
         try {

--- a/src/main/java/com/zenfulcode/commercify/commercify/integration/mobilepay/MobilePayController.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/integration/mobilepay/MobilePayController.java
@@ -5,6 +5,7 @@ import com.zenfulcode.commercify.commercify.api.responses.PaymentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -37,6 +38,7 @@ public class MobilePayController {
         }
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/webhook")
     public ResponseEntity<String> handleWebhook(
             @RequestParam String paymentReference,


### PR DESCRIPTION

This pull request includes several changes to the security configuration and controller classes to enhance authorization and access control. The most important changes include updating the security filter chain to permit access to additional endpoints, adding authorization annotations to controller methods, and importing necessary security annotations.

### Security Configuration Updates:

* [`src/main/java/com/zenfulcode/commercify/commercify/config/SecurityConfig.java`](diffhunk://#diff-ed746dca5b083facdaee9e0f7590c73742e2f6bafa0d27f9639ae4edd8ed2e17L38-R41): Updated the security filter chain to permit access to the `/api/v1/orders`, `/api/v1/payments/mobilepay/create`, and `/api/v1/payments/stripe/create` endpoints.

### Controller Authorization Enhancements:

* [`src/main/java/com/zenfulcode/commercify/commercify/controller/OrderController.java`](diffhunk://#diff-6e6d82f129e2ffacf1dd7dcc2e534487603065e396820f187d42e47c4c9860f7R40): Added `@PreAuthorize` annotation to the `createOrder` method to ensure that only users with the 'USER' role and matching user ID can create orders.
* [`src/main/java/com/zenfulcode/commercify/commercify/integration/mobilepay/MobilePayController.java`](diffhunk://#diff-5dee0197a3832d46b0ae0061b550f4d6386c1fcdf5b82701d87a24074dca419aR41): Added `@PreAuthorize` annotation to the `handleWebhook` method to restrict access to users with the 'ADMIN' role.

### Import Statements:

* [`src/main/java/com/zenfulcode/commercify/commercify/integration/mobilepay/MobilePayController.java`](diffhunk://#diff-5dee0197a3832d46b0ae0061b550f4d6386c1fcdf5b82701d87a24074dca419aR8): Imported `PreAuthorize` annotation to support the new authorization checks.