### PR TITLE
fixing weird relation

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java
@@ -41,8 +41,8 @@ public class UserEntity implements UserDetails {
     private String phoneNumber;
 
     @ToString.Exclude
-    @ManyToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "default_address_id")
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "default_address_id", unique = true)
     private AddressEntity defaultAddress;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -13,4 +13,5 @@
     <include file="db/changelog/migrations/241201215506-changelog.xml"/>
     <include file="db/changelog/migrations/241223151914-changelog.xml"/>
     <include file="db/changelog/migrations/241230175909-changelog.xml"/>
+    <include file="db/changelog/migrations/241230180613-changelog.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/241230180613-changelog.xml
+++ b/src/main/resources/db/changelog/migrations/241230180613-changelog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1735578373817-1" author="gkhaavik">
+        <addUniqueConstraint columnNames="default_address_id" constraintName="uc_users_default_address"
+                             tableName="users"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This pull request includes changes to the `UserEntity` class and database changelog files to enforce unique constraints and update relationships.

Changes to `UserEntity` class:

* Changed the relationship between `UserEntity` and `AddressEntity` from `@ManyToOne` to `@OneToOne` with orphan removal and added a unique constraint on the `default_address_id` column (`src/main/java/com/zenfulcode/commercify/commercify/entity/UserEntity.java`).

Database changelog updates:

* Added a new changelog file `241230180613-changelog.xml` to include a unique constraint on the `default_address_id` column in the `users` table (`src/main/resources/db/changelog/migrations/241230180613-changelog.xml`).
* Included the new changelog file in the master changelog (`src/main/resources/db/changelog/db.changelog-master.xml`).