### PR TITLE
adding new field to OrderDTO to hold orderLinesAmount

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/commercify/dto/OrderDTO.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/dto/OrderDTO.java
@@ -11,11 +11,12 @@ import java.time.Instant;
 @Builder
 @AllArgsConstructor
 public class OrderDTO {
-    private Long id;
+    private long id;
     private Long userId;
     private String currency;
-    private Double totalAmount;
+    private double totalAmount;
     private OrderStatus orderStatus;
+    private int orderLinesAmount;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapper.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapper.java
@@ -19,8 +19,9 @@ public class OrderMapper implements Function<OrderEntity, OrderDTO> {
                 .orderStatus(order.getStatus())
                 .createdAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
-                .currency(order.getCurrency())
-                .totalAmount(order.getTotalAmount())
+                .currency(order.getCurrency() != null ? order.getCurrency() : null)
+                .totalAmount(order.getTotalAmount() != null ? order.getTotalAmount() : 0.0)
+                .orderLinesAmount(order.getOrderLines() != null ? order.getOrderLines().size() : 0)
                 .build();
     }
 }

--- a/src/main/java/com/zenfulcode/commercify/commercify/viewmodel/OrderViewModel.java
+++ b/src/main/java/com/zenfulcode/commercify/commercify/viewmodel/OrderViewModel.java
@@ -6,9 +6,10 @@ import com.zenfulcode.commercify.commercify.dto.OrderDTO;
 import java.time.Instant;
 
 public record OrderViewModel(
-        Long id,
+        long id,
         Long userId,
-        Double totalPrice,
+        int orderLinesAmount,
+        double totalPrice,
         String currency,
         OrderStatus orderStatus,
         Instant createdAt
@@ -17,6 +18,7 @@ public record OrderViewModel(
         return new OrderViewModel(
                 orderDTO.getId(),
                 orderDTO.getUserId(),
+                orderDTO.getOrderLinesAmount(),
                 orderDTO.getTotalAmount(),
                 orderDTO.getCurrency(),
                 orderDTO.getOrderStatus(),

--- a/src/test/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapperTest.java
+++ b/src/test/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapperTest.java
@@ -1,0 +1,108 @@
+package com.zenfulcode.commercify.commercify.dto.mapper;
+
+import com.zenfulcode.commercify.commercify.OrderStatus;
+import com.zenfulcode.commercify.commercify.dto.OrderDTO;
+import com.zenfulcode.commercify.commercify.entity.OrderEntity;
+import com.zenfulcode.commercify.commercify.entity.OrderLineEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderMapperTest {
+
+    @InjectMocks
+    private OrderMapper orderMapper;
+
+    private OrderEntity orderEntity;
+
+    @BeforeEach
+    void setUp() {
+        Instant now = Instant.now();
+
+        Set<OrderLineEntity> orderLines = new LinkedHashSet<>();
+        OrderLineEntity orderLine = OrderLineEntity.builder()
+                .id(1L)
+                .productId(1L)
+                .quantity(2)
+                .unitPrice(99.99)
+                .currency("USD")
+                .build();
+        orderLines.add(orderLine);
+
+        orderEntity = OrderEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .orderLines(orderLines)
+                .status(OrderStatus.PENDING)
+                .currency("USD")
+                .totalAmount(199.98)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Should map OrderEntity to OrderDTO correctly")
+    void apply_Success() {
+        OrderDTO result = orderMapper.apply(orderEntity);
+
+        assertNotNull(result);
+        assertEquals(orderEntity.getId(), result.getId());
+        assertEquals(orderEntity.getUserId(), result.getUserId());
+        assertEquals(orderEntity.getStatus(), result.getOrderStatus());
+        assertEquals(orderEntity.getCurrency(), result.getCurrency());
+        assertEquals(orderEntity.getTotalAmount(), result.getTotalAmount());
+        assertEquals(orderEntity.getCreatedAt(), result.getCreatedAt());
+        assertEquals(orderEntity.getUpdatedAt(), result.getUpdatedAt());
+        assertEquals(orderEntity.getOrderLines().size(), result.getOrderLinesAmount());
+    }
+
+    @Test
+    @DisplayName("Should handle OrderEntity with null values")
+    void apply_HandlesNullValues() {
+        OrderEntity emptyOrder = OrderEntity.builder()
+                .id(1L)
+                .build();
+
+        OrderDTO result = orderMapper.apply(emptyOrder);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(0, result.getOrderLinesAmount());
+        assertNull(result.getUserId());
+        assertNull(result.getCurrency());
+        assertEquals(0.0, result.getTotalAmount());
+    }
+
+    @Test
+    @DisplayName("Should handle null totalAmount correctly")
+    void apply_HandlesNullTotalAmount() {
+        orderEntity.setTotalAmount(null);
+
+        OrderDTO result = orderMapper.apply(orderEntity);
+
+        assertNotNull(result);
+        assertEquals(0.0, result.getTotalAmount());
+    }
+
+    @Test
+    @DisplayName("Should handle null orderLines correctly")
+    void apply_HandlesNullOrderLines() {
+        orderEntity.setOrderLines(null);
+
+        OrderDTO result = orderMapper.apply(orderEntity);
+
+        assertNotNull(result);
+        assertEquals(0, result.getOrderLinesAmount());
+    }
+}


### PR DESCRIPTION
This pull request includes changes to the `OrderDTO`, `OrderMapper`, `OrderViewModel`, and associated test files to enhance data consistency and add new functionality for handling order lines. The most important changes include updating data types, adding a new field for order lines amount, and implementing comprehensive tests for the `OrderMapper`.

### Data Type Updates:
* [`src/main/java/com/zenfulcode/commercify/commercify/dto/OrderDTO.java`](diffhunk://#diff-fb6941011fbad3d4d1095d688a74c4d3062f22560419b5c0386c01d667db8e37L14-R19): Changed `id` and `totalAmount` from `Long` and `Double` to `long` and `double` respectively. Added `orderLinesAmount` field.
* [`src/main/java/com/zenfulcode/commercify/commercify/viewmodel/OrderViewModel.java`](diffhunk://#diff-e8bdab7b35b482d98cc394c389ece3796894747c59e3a47ca3c05e660ab9fd1eL9-R12): Changed `id` and `totalPrice` from `Long` and `Double` to `long` and `double` respectively. Added `orderLinesAmount` field.

### Handling Null Values:
* [`src/main/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapper.java`](diffhunk://#diff-0eb665d4e9eebc5f1735e52d7fb293512b4a2827ca7300a0d86f51e122888f1dL22-R24): Updated `apply` method to handle null values for `currency`, `totalAmount`, and `orderLines`.

### ViewModel Updates:
* [`src/main/java/com/zenfulcode/commercify/commercify/viewmodel/OrderViewModel.java`](diffhunk://#diff-e8bdab7b35b482d98cc394c389ece3796894747c59e3a47ca3c05e660ab9fd1eR21): Updated `fromDTO` method to include `orderLinesAmount`.

### Testing Enhancements:
* [`src/test/java/com/zenfulcode/commercify/commercify/dto/mapper/OrderMapperTest.java`](diffhunk://#diff-01f00f99df42275bf79b0d23d06fc2649ca04c6e8f1dd1208917430b97c39b2fR1-R108): Added comprehensive tests for `OrderMapper` to verify correct mapping and handling of null values.adding tests for OrderMapper