### PR TITLE
fixing missing values in order confirmations

### DIFF
--- a/src/main/resources/templates/new-order-notification-email.html
+++ b/src/main/resources/templates/new-order-notification-email.html
@@ -134,7 +134,7 @@
     </table>
 
     <p class="total">Total Amount: <span
-            th:text="${#numbers.formatDecimal(order.totalAmount, 1, 2) + ' ' + order.currency}">$99.99</span></p>
+            th:text="${#numbers.formatDecimal(order.totalPrice, 1, 2) + ' ' + order.currency}">$99.99</span></p>
 </div>
 
 <a th:href="${dashboardUrl}" class="action-button">View Order in Dashboard</a>

--- a/src/main/resources/templates/order-confirmation-email.html
+++ b/src/main/resources/templates/order-confirmation-email.html
@@ -112,7 +112,7 @@
     </table>
 
     <p class="total">Total Amount: <span
-            th:text="${#numbers.formatDecimal(order.totalAmount, 1, 2) + ' ' + order.currency}">$99.99</span></p>
+            th:text="${#numbers.formatDecimal(order.totalPrice, 1, 2) + ' ' + order.currency}">$99.99</span></p>
 </div>
 
 <p th:if="${order.status == 'PENDING'}">
@@ -129,7 +129,5 @@
 </p>
 
 <p>If you have any questions about your order, please contact our customer service.</p>
-
-<p>Best regards,<br/>Commercify Team</p>
 </body>
 </html>


### PR DESCRIPTION
This pull request includes changes to the email templates to ensure consistency in the variable names used for total amounts and to clean up unnecessary text in the order confirmation email. 

Template updates for consistency:

* [`src/main/resources/templates/new-order-notification-email.html`](diffhunk://#diff-f1b2165ec79c6c51bf84e32fb90dc8aaeef47fb6e2ea4b98db22f3dd51ebc564L137-R137): Changed the variable name from `order.totalAmount` to `order.totalPrice` to ensure consistency.
* [`src/main/resources/templates/order-confirmation-email.html`](diffhunk://#diff-489a6923d1c0fcfb849c12b1d9fa1fba375ddce9575eb2260535b83db4bf0c39L115-R115): Changed the variable name from `order.totalAmount` to `order.totalPrice` to ensure consistency.

Cleanup in order confirmation email:

* [`src/main/resources/templates/order-confirmation-email.html`](diffhunk://#diff-489a6923d1c0fcfb849c12b1d9fa1fba375ddce9575eb2260535b83db4bf0c39L132-L133): Removed unnecessary closing text to clean up the email content.