### PR TITLE
Refactor product retrieval methods for improved clarity

### DIFF
--- a/src/main/java/com/zenfulcode/commercify/api/product/ProductController.java
+++ b/src/main/java/com/zenfulcode/commercify/api/product/ProductController.java
@@ -53,8 +53,7 @@ public class ProductController {
     @GetMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
             @PathVariable String productId) {
-
-        Product product = productApplicationService.getProduct(ProductId.of(productId));
+        Product product = productApplicationService.getProductById(ProductId.of(productId));
         ProductDetailResponse response = dtoMapper.toDetailResponse(product);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/zenfulcode/commercify/product/application/service/ProductApplicationService.java
+++ b/src/main/java/com/zenfulcode/commercify/product/application/service/ProductApplicationService.java
@@ -170,9 +170,8 @@ public class ProductApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public Product getProduct(ProductId productId) {
-        return productRepository.findById(productId)
-                .orElseThrow(() -> new ProductNotFoundException(productId));
+    public Product getProductById(ProductId productId) {
+        return productDomainService.getProductById(productId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/zenfulcode/commercify/product/domain/model/ProductVariant.java
+++ b/src/main/java/com/zenfulcode/commercify/product/domain/model/ProductVariant.java
@@ -40,7 +40,7 @@ public class ProductVariant {
     })
     private Money price;
 
-    @OneToMany(mappedBy = "productVariant")
+    @OneToMany(mappedBy = "productVariant", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<VariantOption> variantOptions = new LinkedHashSet<>();
 
     public static ProductVariant create(String sku, Integer stock, Money price, String imageUrl) {

--- a/src/main/java/com/zenfulcode/commercify/product/domain/service/ProductDomainService.java
+++ b/src/main/java/com/zenfulcode/commercify/product/domain/service/ProductDomainService.java
@@ -2,10 +2,12 @@ package com.zenfulcode.commercify.product.domain.service;
 
 import com.zenfulcode.commercify.order.domain.repository.OrderLineRepository;
 import com.zenfulcode.commercify.product.domain.exception.InvalidPriceException;
+import com.zenfulcode.commercify.product.domain.exception.ProductNotFoundException;
 import com.zenfulcode.commercify.product.domain.exception.ProductValidationException;
 import com.zenfulcode.commercify.product.domain.exception.VariantNotFoundException;
 import com.zenfulcode.commercify.product.domain.model.Product;
 import com.zenfulcode.commercify.product.domain.model.ProductVariant;
+import com.zenfulcode.commercify.product.domain.repository.ProductRepository;
 import com.zenfulcode.commercify.product.domain.valueobject.*;
 import com.zenfulcode.commercify.shared.domain.model.Money;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class ProductDomainService {
     private final OrderLineRepository orderLineRepository;
+    private final ProductRepository productRepository;
     private final ProductInventoryPolicy inventoryPolicy;
     private final ProductPricingPolicy pricingPolicy;
     private final ProductFactory productFactory;
@@ -187,6 +190,12 @@ public class ProductDomainService {
         if (updateSpec.hasStockUpdate()) {
             inventoryPolicy.initializeInventory(product);
         }
+    }
+
+    public Product getProductById(ProductId productId) {
+        return productRepository.findById(productId).orElseThrow(
+                () -> new ProductNotFoundException(productId)
+        );
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the product management functionality in the `commercify` application. The most important changes involve renaming methods for clarity, updating the fetching strategy for related entities, and adding necessary imports and dependencies.

### Method Renaming:
* Renamed `getProduct` to `getProductById` in `ProductApplicationService` and updated its usage in `ProductController` to improve clarity and consistency. [[1]](diffhunk://#diff-8c47de843bb29cc8bca88f55c81b029802cf373410d04095a812ee53b31ead4aL56-R56) [[2]](diffhunk://#diff-d937d3e2a50f6efc52aba29ed3497f37c6c16d86959b5552447754ee44660b0dL173-R174)

### Fetch Strategy Update:
* Updated the `ProductVariant` class to use lazy fetching and cascade all operations for `variantOptions` to optimize performance and ensure proper cascading of operations.

### Dependency Additions:
* Added `ProductNotFoundException` and `ProductRepository` imports to `ProductDomainService` to support the new `getProductById` method. [[1]](diffhunk://#diff-0bbc81dfba231f344619cc5958741fd4939e222d0b7a59042d11ec8ebd139e69R5-R10) [[2]](diffhunk://#diff-0bbc81dfba231f344619cc5958741fd4939e222d0b7a59042d11ec8ebd139e69R24)

### New Method:
* Added `getProductById` method in `ProductDomainService` to handle product retrieval by ID, throwing a `ProductNotFoundException` if the product is not found.