### PR TITLE
update Postman workspace link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ mvn spring-boot:run
 
 View and test the API endpoints in our Postman Workspace.
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/flight-physicist-84721578/workspace/commercify-backend)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/zenfulcode/workspace/commercify-rest-api)
 
 ## Security
 


### PR DESCRIPTION
This pull request updates the Postman Workspace link in the `README.md` file to point to the correct workspace for the `commercify-rest-api`.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R86): Updated the Postman Workspace link from `flight-physicist-84721578/workspace/commercify-backend` to `zenfulcode/workspace/commercify-rest-api` to ensure users access the correct API testing workspace.